### PR TITLE
feat: compress text to shorten the encoded url + replace alert with "copied" text

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@uiw/react-md-editor": "^4.0.6",
     "copy-to-clipboard": "^3.3.3",
+    "lz-string": "^1.5.0",
     "markdown-it": "^14.1.0",
     "marked": "^15.0.11",
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import MDEditor from "@uiw/react-md-editor";
 import copy from "copy-to-clipboard";
 import "./App.css";
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string'
 
 function App() {
   const [markdown, setMarkdown] = useState<string>(
@@ -13,12 +14,12 @@ function App() {
 
   // Base64 utility functions
   const encodeContent = (content: string): string => {
-    return btoa(unescape(encodeURIComponent(content)));
+    return compressToEncodedURIComponent(content);
   };
 
   const decodeContent = (encoded: string): string => {
     try {
-      return decodeURIComponent(escape(atob(encoded)));
+      return decompressFromEncodedURIComponent(encoded);
     } catch (error) {
       console.error("Failed to decode base64 content", error);
       return "";
@@ -87,7 +88,16 @@ function App() {
 
   const handleCopy = () => {
     copy(window.location.href);
-    alert("URL copied to clipboard!");
+    // Add a temporary "Copied!" message
+    const button = document.querySelector('.share-button');
+    const originalText = button?.textContent;
+    if (button) {
+      button.textContent = 'Copied!';
+      setTimeout(() => {
+      if (button && originalText) button.textContent = originalText;
+      }, 2000);
+    }
+    
   };
 
   return (


### PR DESCRIPTION
- The code now uses "lz-string" to compress and decompress text to handle longer text. 
- replaced the "link copied" alert with updating the button text to "copied"

p.s. versel would send a [URL_TOO_LONG](https://vercel.com/docs/errors/URL_TOO_LONG) for links longer than 14kb 